### PR TITLE
Add support for reversal operations in the Tranzila gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ For general usage instructions, please see the main [Omnipay](https://github.com
 
 ### Authorization
 
+Authorization operations support two methods:
+
+#### Method 1: Credit Card Details
 ```php
 use Omnipay\Omnipay;
 
@@ -54,6 +57,33 @@ $response = $gateway->authorize([
         'expiryYear' => '2025',
         'cvv' => '123'
     ]
+])->send();
+
+if ($response->isSuccessful()) {
+    // authorization was successful: update database
+    $transactionReference = $response->getTransactionReference();
+    print_r($response);
+} else {
+    // authorization failed: display message to customer
+    echo $response->getMessage();
+}
+```
+
+#### Method 2: Token + Expiry
+```php
+use Omnipay\Omnipay;
+
+$gateway = Omnipay::create('Tranzila');
+$gateway->setAppKey('your_app_key');
+$gateway->setSecret('your_secret');
+$gateway->setTerminalName('your_terminal_name');
+
+$response = $gateway->authorize([
+    'amount' => '10.00',
+    'currency' => 'ILS',
+    'token' => 'U99e9abcd81c2ca4444',
+    'expiryMonth' => 12,
+    'expiryYear' => 2025
 ])->send();
 
 if ($response->isSuccessful()) {
@@ -133,6 +163,8 @@ if ($response->isSuccessful()) {
 
 ### Void
 
+Void operations require both transaction reference and authorization number:
+
 ```php
 use Omnipay\Omnipay;
 
@@ -142,7 +174,8 @@ $gateway->setSecret('your_secret');
 $gateway->setTerminalName('your_terminal_name');
 
 $response = $gateway->void([
-    'transactionReference' => '12345' // The transaction reference to void
+    'transactionReference' => '12345', // The transaction reference to void
+    'authorizationNumber' => 'AUTH123' // Authorization number from the original transaction
 ])->send();
 
 if ($response->isSuccessful()) {
@@ -159,8 +192,61 @@ if ($response->isSuccessful()) {
 
 > **Note:** Void responses have a simpler format than other transactions. A successful void returns `{"error_code":0,"message":"Success"}` without a `transaction_result` object.
 
+### Reversal
+
+Reversal operations require transaction reference, authorization number, and either token+expiry or card details:
+
+```php
+use Omnipay\Omnipay;
+
+$gateway = Omnipay::create('Tranzila');
+$gateway->setAppKey('your_app_key');
+$gateway->setSecret('your_secret');
+$gateway->setTerminalName('your_terminal_name');
+
+$response = $gateway->reversal([
+    'amount' => '1.00',
+    'currency' => 'ILS',
+    'transactionReference' => '12345', // The transaction reference to reverse
+    'authorizationNumber' => 'AUTH123', // Authorization number from the original transaction
+    'token' => 's0fc7b9882e722b0691', // Token from the original transaction
+    'expiryMonth' => 11,
+    'expiryYear' => 2028
+])->send();
+
+if ($response->isSuccessful()) {
+    // reversal was successful: update database
+    $transactionReference = $response->getTransactionReference();
+    print_r($response);
+} else {
+    // reversal failed: display message to customer
+    echo $response->getMessage();
+}
+```
+
+**Alternative: Using Card Details**
+```php
+$response = $gateway->reversal([
+    'amount' => '1.00',
+    'currency' => 'ILS',
+    'transactionReference' => '12345',
+    'authorizationNumber' => 'AUTH123',
+    'card' => [
+        'number' => '4111111111111111',
+        'expiryMonth' => '11',
+        'expiryYear' => '2028',
+        'cvv' => '123'
+    ]
+])->send();
+```
+
+> **Note:** Reversal operations require the original transaction reference, authorization number, and either the token with expiry or complete card details from the original transaction.
+
 ### Verification
 
+Verification operations support two methods:
+
+#### Method 1: Credit Card Details
 ```php
 use Omnipay\Omnipay;
 
@@ -190,8 +276,38 @@ if ($response->isSuccessful()) {
 }
 ```
 
+#### Method 2: Token + Expiry
+```php
+use Omnipay\Omnipay;
+
+$gateway = Omnipay::create('Tranzila');
+$gateway->setAppKey('your_app_key');
+$gateway->setSecret('your_secret');
+$gateway->setTerminalName('your_terminal_name');
+
+$response = $gateway->verify([
+    'amount' => '10.00',
+    'currency' => 'ILS',
+    'token' => 'U99e9abcd81c2ca4444',
+    'expiryMonth' => 12,
+    'expiryYear' => 2025
+])->send();
+
+if ($response->isSuccessful()) {
+    // verification was successful: update database
+    $transactionReference = $response->getTransactionReference();
+    print_r($response);
+} else {
+    // verification failed: display message to customer
+    echo $response->getMessage();
+}
+```
+
 ### Purchase
 
+Purchase operations support two methods:
+
+#### Method 1: Credit Card Details
 ```php
 use Omnipay\Omnipay;
 
@@ -220,11 +336,37 @@ if ($response->isSuccessful()) {
 }
 ```
 
+#### Method 2: Token + Expiry
+```php
+use Omnipay\Omnipay;
+
+$gateway = Omnipay::create('Tranzila');
+$gateway->setAppKey('your_app_key');
+$gateway->setSecret('your_secret');
+$gateway->setTerminalName('your_terminal_name');
+
+$response = $gateway->purchase([
+    'amount' => '10.00',
+    'currency' => 'ILS',
+    'token' => 'U99e9abcd81c2ca4444',
+    'expiryMonth' => 12,
+    'expiryYear' => 2025
+])->send();
+
+if ($response->isSuccessful()) {
+    // payment was successful: update database
+    print_r($response);
+} else {
+    // payment failed: display message to customer
+    echo $response->getMessage();
+}
+```
+
 ### Refund
 
-Refund operations support three different methods:
+Refund operations require authorization number + transaction reference + either token+expiry OR card details:
 
-#### Method 1: Authorization Number + Transaction Reference
+#### Method 1: Authorization Number + Transaction Reference + Token + Expiry
 ```php
 use Omnipay\Omnipay;
 
@@ -237,30 +379,7 @@ $response = $gateway->refund([
     'amount' => '10.00',
     'currency' => 'ILS',
     'transactionReference' => '12345',
-    'authorizationNumber' => 'AUTH123'
-])->send();
-
-if ($response->isSuccessful()) {
-    // refund was successful: update database
-    print_r($response);
-} else {
-    // refund failed: display message to customer
-    echo $response->getMessage();
-}
-```
-
-#### Method 2: Token + Expiry
-```php
-use Omnipay\Omnipay;
-
-$gateway = Omnipay::create('Tranzila');
-$gateway->setAppKey('your_app_key');
-$gateway->setSecret('your_secret');
-$gateway->setTerminalName('your_terminal_name');
-
-$response = $gateway->refund([
-    'amount' => '10.00',
-    'currency' => 'ILS',
+    'authorizationNumber' => 'AUTH123',
     'token' => 'U99e9abcd81c2ca4444',
     'expiryMonth' => 12,
     'expiryYear' => 2025
@@ -275,7 +394,7 @@ if ($response->isSuccessful()) {
 }
 ```
 
-#### Method 3: Credit Card Details
+#### Method 2: Authorization Number + Transaction Reference + Credit Card Details
 ```php
 use Omnipay\Omnipay;
 
@@ -287,6 +406,8 @@ $gateway->setTerminalName('your_terminal_name');
 $response = $gateway->refund([
     'amount' => '10.00',
     'currency' => 'ILS',
+    'transactionReference' => '12345',
+    'authorizationNumber' => 'AUTH123',
     'card' => [
         'number' => '4111111111111111',
         'expiryMonth' => '12',
@@ -365,12 +486,13 @@ if ($response->isSuccessful()) {
 
 This gateway supports the following payment methods:
 
-- `authorize()` - Authorize a payment
+- `authorize()` - Authorize a payment (supports token+expiry or card details)
 - `capture()` - Capture a previously authorized payment (requires transaction reference, authorization number, and either token+expiry or card details)
-- `purchase()` - Authorize and capture a payment in one step
-- `refund()` - Refund a payment (supports authorization number, token, or card details)
-- `void()` - Void a payment
-- `verify()` - Verify a card without charging
+- `purchase()` - Authorize and capture a payment in one step (supports token+expiry or card details)
+- `refund()` - Refund a payment (requires authorization number+transaction reference+token+expiry OR authorization number+transaction reference+card details)
+- `void()` - Void a payment (requires transaction reference and authorization number)
+- `reversal()` - Reverse a payment (requires transaction reference, authorization number, and either token+expiry or card details)
+- `verify()` - Verify a card without charging (supports token+expiry or card details)
 - `handshake()` - Get iframe token for secure payment form
 
 ## Supported Currencies

--- a/src/Gateway.php
+++ b/src/Gateway.php
@@ -8,7 +8,7 @@ use Omnipay\Tranzila\Message\Requests\CaptureRequest;
 use Omnipay\Tranzila\Message\Requests\HandshakeRequest;
 use Omnipay\Tranzila\Message\Requests\PurchaseRequest;
 use Omnipay\Tranzila\Message\Requests\RefundRequest;
-
+use Omnipay\Tranzila\Message\Requests\ReversalRequest;
 use Omnipay\Tranzila\Message\Requests\VerifyRequest;
 use Omnipay\Tranzila\Message\Requests\VoidRequest;
 
@@ -98,6 +98,11 @@ class Gateway extends AbstractGateway
     public function void(array $options = [])
     {
         return $this->createRequest(VoidRequest::class, $options);
+    }
+
+    public function reversal(array $options = [])
+    {
+        return $this->createRequest(ReversalRequest::class, $options);
     }
 
     public function handshake(array $options = [])

--- a/tests/Message/ReversalRequestTest.php
+++ b/tests/Message/ReversalRequestTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Omnipay\Tranzila\Tests\Message;
+
+use Omnipay\Common\CreditCard;
+use Omnipay\Tests\TestCase;
+use Omnipay\Tranzila\Message\Requests\ReversalRequest;
+use Omnipay\Tranzila\Message\Responses\Response;
+
+class ReversalRequestTest extends TestCase
+{
+    protected ReversalRequest $request;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->request = new ReversalRequest($this->getHttpClient(), $this->getHttpRequest());
+        $this->request->initialize([
+            'app_key' => 'test_app_key',
+            'secret' => 'test_secret',
+            'terminal_name' => 'test_terminal',
+            'amount' => '10.00',
+            'currency' => 'ILS',
+            'transaction_reference' => '12345',
+            'authorization_number' => 'AUTH123',
+        ]);
+    }
+
+    public function testGetDataWithCard()
+    {
+        $card = new CreditCard([
+            'number' => '4111111111111111',
+            'expiryMonth' => '12',
+            'expiryYear' => '2025',
+            'cvv' => '123',
+        ]);
+
+        $this->request->setCard($card);
+
+        $data = $this->request->getData();
+
+        $this->assertSame('test_terminal', $data['terminal_name']);
+        $this->assertSame('reversal', $data['txn_type']);
+        $this->assertSame(12345, $data['reference_txn_id']);
+        $this->assertSame('AUTH123', $data['authorization_number']);
+        $this->assertSame('4111111111111111', $data['card_number']);
+        $this->assertSame(12, $data['expire_month']);
+        $this->assertSame(2025, $data['expire_year']);
+        $this->assertSame('123', $data['cvv']);
+        $this->assertSame('Reversal', $data['items'][0]['name']);
+        $this->assertSame('I', $data['items'][0]['type']);
+        $this->assertSame(10.0, $data['items'][0]['unit_price']);
+        $this->assertSame(1, $data['items'][0]['units_number']);
+    }
+
+    public function testGetDataWithToken()
+    {
+        $this->request->setToken('U99e9abcd81c2ca4444');
+        $this->request->setExpiryMonth(11);
+        $this->request->setExpiryYear(2028);
+
+        $data = $this->request->getData();
+
+        $this->assertSame('test_terminal', $data['terminal_name']);
+        $this->assertSame('reversal', $data['txn_type']);
+        $this->assertSame(12345, $data['reference_txn_id']);
+        $this->assertSame('AUTH123', $data['authorization_number']);
+        $this->assertSame('U99e9abcd81c2ca4444', $data['card_number']);
+        $this->assertSame(11, $data['expire_month']);
+        $this->assertSame(2028, $data['expire_year']);
+        $this->assertMatchesRegularExpression('/^\d{3}$/', $data['cvv']); // Random 3-digit CVV
+        $this->assertSame('Reversal', $data['items'][0]['name']);
+        $this->assertSame('I', $data['items'][0]['type']);
+        $this->assertSame(10.0, $data['items'][0]['unit_price']);
+        $this->assertSame(1, $data['items'][0]['units_number']);
+    }
+
+    public function testGetDataWithDescription()
+    {
+        $card = new CreditCard([
+            'number' => '4111111111111111',
+            'expiryMonth' => '12',
+            'expiryYear' => '2025',
+            'cvv' => '123',
+        ]);
+
+        $this->request->setCard($card);
+        $this->request->setDescription('Custom Reversal Description');
+
+        $data = $this->request->getData();
+
+        $this->assertSame('Custom Reversal Description', $data['items'][0]['name']);
+    }
+
+    public function testValidationRequiresTransactionReference()
+    {
+        $this->request->setTransactionReference(null);
+
+        $this->expectException(\Omnipay\Common\Exception\InvalidRequestException::class);
+        $this->request->getData();
+    }
+
+    public function testValidationRequiresAuthorizationNumber()
+    {
+        $this->request->setAuthorizationNumber(null);
+
+        $this->expectException(\Omnipay\Common\Exception\InvalidRequestException::class);
+        $this->request->getData();
+    }
+
+    public function testValidationRequiresCardWhenNoToken()
+    {
+        // No card or token set
+        $this->expectException(\Omnipay\Common\Exception\InvalidRequestException::class);
+        $this->request->getData();
+    }
+
+    public function testSendData()
+    {
+        $card = new CreditCard([
+            'number' => '4111111111111111',
+            'expiryMonth' => '12',
+            'expiryYear' => '2025',
+            'cvv' => '123',
+        ]);
+
+        $this->request->setCard($card);
+
+        $this->setMockHttpResponse('ReversalSuccess.txt');
+
+        $response = $this->request->send();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertTrue($response->isSuccessful());
+    }
+
+    public function testReversalWithInvalidReference()
+    {
+        $card = new CreditCard([
+            'number' => '4111111111111111',
+            'expiryMonth' => '12',
+            'expiryYear' => '2025',
+            'cvv' => '123',
+        ]);
+
+        $this->request->setCard($card);
+
+        $this->setMockHttpResponse('ReversalFailure.txt');
+
+        $response = $this->request->send();
+
+        $this->assertInstanceOf(Response::class, $response);
+        $this->assertFalse($response->isSuccessful());
+    }
+}

--- a/tests/Mock/ReversalFailure.txt
+++ b/tests/Mock/ReversalFailure.txt
@@ -1,0 +1,18 @@
+HTTP/1.1 400 Bad Request
+Content-Type: application/json
+
+{
+    "error_code": 20112,
+    "message": "Original transaction not found",
+    "transaction_result": {
+        "processor_response_code": "001",
+        "transaction_id": null,
+        "auth_number": null,
+        "card_type": null,
+        "card_type_name": null,
+        "currency_code": "ILS",
+        "amount": 10.00,
+        "txn_type": "reversal",
+        "tranmode": "A"
+    }
+}


### PR DESCRIPTION
- Introduced `reversal()` method in the Gateway class.
- Implemented ReversalRequest to handle both token-based and card-based reversals.
- Updated README.md with detailed instructions for reversal operations.
- Added tests for ReversalRequest to ensure proper functionality and validation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the "reversal" transaction type, enabling reversal operations using either credit card details or token with expiry.
* **Documentation**
  * Expanded and clarified usage instructions, including detailed examples for all operations and new guidance for reversal transactions.
  * Updated requirements and parameter details for authorization, verification, purchase, refund, capture, and void operations.
  * Added notes on response formats and sandbox limitations.
* **Tests**
  * Introduced comprehensive tests for reversal transactions, covering both card and token methods, validation, and response handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->